### PR TITLE
[feat]: add details about .env file in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install dependencies before running
 npm install
 ```
 
-Set the following environment variables to `1`
+Open a `.env` file and set the following environment variables to `1` in the file:
 
 - `ANGOLIA_APP_ID`
 - `ANGOLIA_API_KEY`


### PR DESCRIPTION
The description of environment file in the `README.md` was not clear. I thought it would be easy to understand to make it clear.