### PR TITLE
fix typo Update axiom-cli.md

### DIFF
--- a/docs/sdk/typescript-sdk/axiom-cli.md
+++ b/docs/sdk/typescript-sdk/axiom-cli.md
@@ -130,7 +130,7 @@ Options:
   -p, --provider [provider]                    JSON-RPC provider (https)
   -pv, --proven [proven]                       `axiom circuit prove` outputs path
   -o, --outputs [outputs]                      query-params outputs path
-  -a, --args-map                               sendQuery argments output as mapping for use with Forge
+  -a, --args-map                               sendQuery arguments output as mapping for use with Forge
 ```
 
 - callback address: the target contract address with the callback function


### PR DESCRIPTION
### Fix Typo in axiom-cli.md

This pull request addresses a minor typo in the `axiom-cli.md` documentation.

#### Changes Made:
- Corrected "argments" to "arguments" in the CLI option descriptions.

---

This change enhances the clarity and professionalism of the documentation for users navigating CLI options.
