### PR TITLE
fix typo Update caching-block-hashes.md

### DIFF
--- a/docs/protocol/protocol-design/caching-block-hashes.md
+++ b/docs/protocol/protocol-design/caching-block-hashes.md
@@ -81,7 +81,7 @@ The latest padded Merkle mountain range is stored in `blockhashPmmr`. The mappin
 mapping(uint32 => bytes32) public pmmrSnapshots;
 ```
 
-caches commitments to recent values of `blockhashPmmr` to faciliate asynchronous proving against a Merkle mountain range which may be updated on-chain during proving.
+caches commitments to recent values of `blockhashPmmr` to facilitate asynchronous proving against a Merkle mountain range which may be updated on-chain during proving.
 
 Updates to `blockhashPmmr` are made using newly verified Merkle roots added to [`historicalRoots`](caching-block-hashes.md#caching-merkle-roots-of-block-hashes). Updates are made either alongside `historicalRoots` updates in [`updateRecent`](caching-block-hashes.md#caching-merkle-roots-of-block-hashes) or by calling `appendHistoricalMMR`, which has the following function signature:
 


### PR DESCRIPTION
### Title:
Fix typo in caching-block-hashes.md

### Description:
This pull request corrects a typographical error in the `caching-block-hashes.md` documentation file, replacing "faciliate" with "facilitate." Accurate documentation ensures better understanding and usability.

### Changes Made:
- Corrected "faciliate" to "facilitate" in the file.

---

Please let me know if additional edits are required. Thank you for your time and review!
