### PR TITLE
fix typo Update getting-started-with-halo2.md

### DIFF
--- a/docs/protocol/zero-knowledge-proofs/getting-started-with-halo2.md
+++ b/docs/protocol/zero-knowledge-proofs/getting-started-with-halo2.md
@@ -464,6 +464,6 @@ Lastly, the improvement to proving time performance from increasing the number o
 
 ## Saved reading for later
 
-If you find that `halo2-lib` does not provide enough functionality for your ZK circuit needs, or if you are just curious, you can check out the full "vanilla" Halo2 API documention in the [halo2 book](https://zcash.github.io/halo2/).&#x20;
+If you find that `halo2-lib` does not provide enough functionality for your ZK circuit needs, or if you are just curious, you can check out the full "vanilla" Halo2 API documentation in the [halo2 book](https://zcash.github.io/halo2/).&#x20;
 
 - We have also assembled a [Halo2 Cheatsheet](https://hackmd.io/@axiom/HyoXzD7Zh) with a growing collection of observations we found helpful when first interacting with the vanilla Halo2 API.&#x20;


### PR DESCRIPTION
### Title:
Fix typo in `getting-started-with-halo2.md`

### Description:
This pull request corrects a typo in the `getting-started-with-halo2.md` file:

- Fixed the spelling of "documtion" to "documentation."

Thank you for reviewing the changes!
